### PR TITLE
Fix undefined behaviors while sorting uniform arrays.

### DIFF
--- a/operator/ones-sort-lambda-conv.cc
+++ b/operator/ones-sort-lambda-conv.cc
@@ -19,7 +19,7 @@ int main()
   bool ascending {false};
   sort(numbers.begin(), numbers.end(),
        [=](const Number &a, const Number &b)
-       {return((ascending)? (a < b) :!(a < b));});
+       {return((ascending)? (a < b) :(a > b));});
   cout << "with capturing ascending" << endl;
   for (auto number : numbers)
     number.print();

--- a/operator/ones-sort-lambda.cc
+++ b/operator/ones-sort-lambda.cc
@@ -20,7 +20,7 @@ int main()
   bool ascending {false};
   sort(numbers.begin(), numbers.end(),
        [=](const Number &a, const Number &b)
-       {return((ascending)? (a < b) :!(a < b));});
+       {return((ascending)? (a < b) :(a > b));});
   cout << "with capturing ascending" << endl;
   for (auto number : numbers)
     number.print();

--- a/operator/ones.cc
+++ b/operator/ones.cc
@@ -20,3 +20,13 @@ bool Number::operator<(const Number &next) const
     (ones < next.ones || (ones == next.ones &&
       bits.to_ulong() < next.bits.to_ulong()));
 }
+bool Number::operator==(const Number &next) const
+{
+  return
+	(ones == next.ones &&
+	  bits.to_ulong() == next.bits.to_ulong());
+}
+bool Number::operator>(const Number &next) const
+{
+  return(!(*this < next) && !(*this == next));
+}

--- a/operator/ones.h
+++ b/operator/ones.h
@@ -11,6 +11,8 @@ class Number
   int getones() const;
   bitset<4> getbits() const;
   bool operator<(const Number &r) const;
+  bool operator==(const Number &r) const;
+  bool operator>(const Number &r) const;
   void print() const;
 };
 

--- a/operator/rational-sort-comp.cc
+++ b/operator/rational-sort-comp.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 bool comp(const Rational &a, const Rational &b)
 {
-  return(!(a < b));
+  return(a > b);
 }
 int main()
 {

--- a/operator/rational-sort-lambda.cc
+++ b/operator/rational-sort-lambda.cc
@@ -22,7 +22,7 @@ int main()
   bool ascending {false};
   sort(rationals.begin(), rationals.end(),
        [=](const Rational &a, const Rational &b)
-       {return((ascending)? (a < b) :!(a < b));});
+       {return((ascending)? (a < b) :(a > b));});
   cout << "with capturing ascending" << endl;
   for (auto rational : rationals) {
     rational.print();

--- a/operator/rational.cc
+++ b/operator/rational.cc
@@ -36,6 +36,14 @@ bool Rational::operator<(const Rational &a) const
 {
   return(q * a.p < p * a.q);
 }
+bool Rational::operator==(const Rational &a) const
+{
+  return(p == a.p && q == a.q);
+}
+bool Rational::operator>(const Rational &a) const
+{
+  return(!(*this < a) && !(*this == a));
+}
 int gcd(int a, int b)
 {
   if (a % b == 0)

--- a/operator/rational.h
+++ b/operator/rational.h
@@ -13,6 +13,8 @@ class Rational {
   Rational operator*(const Rational &r) const;
   Rational operator/(const Rational &r) const;
   bool operator<(const Rational &r) const;
+  bool operator==(const Rational &r) const;
+  bool operator>(const Rational &r) const;
   void print(string msg = "", ostream &out = cout) const;
 };
 #endif


### PR DESCRIPTION
The current implementation causes undefined behaviors while attempting to sort uniform arrays. According to [the C++ standard](https://en.cppreference.com/w/cpp/named_req/Compare), comparators for sort must be in strict weak ordering. However, the current implementation, which uses `!(a < b)` as a comparator, is not in such ordering. The resulting binaries segfault on uniform arrays whose size is larger than 16.
This patch introduces the comparator `>` and `==`, and changes all appearances of `!(a < b)` to `a > b`.
Ref: https://stackoverflow.com/questions/45929474/why-must-stdsort-compare-function-return-false-when-arguments-are-equal